### PR TITLE
minimal pyproject.toml for pip 24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 dist/
 *.egg-info/
+*.so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
See **https://packaging.python.org/en/latest/guides/modernize-setup-py-project/**

The addition of this minimal pyproject.toml file seems to be all that is required to make this package compatible with the latest Python and pip. I would appreciate it if you would update the package on pypi with this so that our own installation will continue to work without pinning us to an old version of pip. Thank you.