### PR TITLE
build: wheels for arm platforms

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -60,7 +60,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-14]
+        os:
+          - ubuntu-24.04 # Linux, x64
+          - ubuntu-24.04-arm # Linux, arm64
+          - windows-2025 # Windows, x64
+          - windows-11-arm # Windows, arm64
+          - macOS-15 # macOS, arm64
+          - macOS-15-intel # macOS, x64
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
This PR adds support to build wheels for arm platforms - this is particularly useful for installations within Docker on ARM Macs, but also Linux platforms with arm CPUs.

I added Windows on arm and macOS on intel (x64) for completeness.