### PR TITLE
free-threading support

### DIFF
--- a/polyleven.c
+++ b/polyleven.c
@@ -381,15 +381,26 @@ static PyMethodDef polyleven_methods[] = {
     {NULL, NULL, 0, NULL}
 };
 
+static PyModuleDef_Slot polyleven_slots[] = {
+#ifdef Py_mod_gil
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL}
+};
+
 static struct PyModuleDef polyleven_definition = {
     PyModuleDef_HEAD_INIT,
     "polyleven",
     "Hyperfast Levenshtein distance library",
-    -1,
-    polyleven_methods
+    0,  /* m_size: 0 for multi-phase init (no per-module state) */
+    polyleven_methods,
+    polyleven_slots,
+    NULL,  /* m_traverse */
+    NULL,  /* m_clear */
+    NULL   /* m_free */
 };
 
 PyMODINIT_FUNC PyInit_polyleven(void)
 {
-    return PyModule_Create(&polyleven_definition);
+    return PyModuleDef_Init(&polyleven_definition);
 }


### PR DESCRIPTION
this PR adds free-threaded compatibility and stops this message from being displayed:


`<frozen importlib._bootstrap>:491: RuntimeWarning: The global interpreter lock (GIL) has been enabled to load module 'polyleven', which has not declared that it can run safely without the GIL. To override this behavior and keep the GIL disabled (at your own risk), run with PYTHON_GIL=0 or -Xgil=0.`
